### PR TITLE
Implement caching for brewery data retrieval

### DIFF
--- a/BreweryAPI/Repositories/BreweryApiRepository.cs
+++ b/BreweryAPI/Repositories/BreweryApiRepository.cs
@@ -5,21 +5,32 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using BreweryAPI.Models;
 using BreweryAPI.Repositories.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace BreweryAPI.Repositories
 {
     public class BreweryApiRepository : IBreweryRepository
     {
         private readonly HttpClient _httpClient;
+        private readonly IMemoryCache _cache;
+        private static readonly string AllBreweriesCacheKey = "all-breweries";
+        private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(10);
 
-        public BreweryApiRepository(HttpClient httpClient)
+        public BreweryApiRepository(HttpClient httpClient, IMemoryCache cache)
         {
             _httpClient = httpClient;
+            _cache = cache;
         }
 
         public async Task<IEnumerable<Brewery>> GetAllBreweriesAsync()
         {
+            if (_cache.TryGetValue(AllBreweriesCacheKey, out List<Brewery>? cachedBreweries) && cachedBreweries != null)
+            {
+                return cachedBreweries;
+            }
+
             var list = await _httpClient.GetFromJsonAsync<List<Brewery>>("breweries?per_page=200");
+            _cache.Set(AllBreweriesCacheKey, list, CacheDuration);
             return list ?? new List<Brewery>();
         }
 

--- a/BreweryAPI/Startup.cs
+++ b/BreweryAPI/Startup.cs
@@ -22,6 +22,8 @@ namespace BreweryAPI
         {
             services.AddControllers();
 
+            services.AddMemoryCache();
+
             services.AddApiVersioning(o =>
             {
                 o.AssumeDefaultVersionWhenUnspecified = true;


### PR DESCRIPTION
Introduce caching for brewery data retrieval to improve performance and reduce API calls. Update the repository constructor to accept a memory cache instance.