### PR TITLE
Implement pagination in brewery retrieval

### DIFF
--- a/BreweryAPI/Controllers/BreweriesController.cs
+++ b/BreweryAPI/Controllers/BreweriesController.cs
@@ -22,7 +22,7 @@ namespace BreweryAPI.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> Get(
+        public async Task<ActionResult<PagedResult<Brewery>>> Get(
             [FromQuery] string? search,
             [FromQuery] string? city,
             [FromQuery] string? sortBy,
@@ -32,7 +32,7 @@ namespace BreweryAPI.Controllers
             [FromQuery] int pageSize = 20)
         {
             page = page < 1 ? 1 : page;
-            pageSize = pageSize < 1 ? 20 : pageSize;
+            pageSize = pageSize < 1 ? 1 : (pageSize > 200 ? 200 : pageSize);
 
             var result = await _breweryLogic.GetAllBreweriesAsync(search, city, sortBy, userLat, userLng, page, pageSize);
             return Ok(result);

--- a/BreweryAPI/Logic/BreweryLogic.cs
+++ b/BreweryAPI/Logic/BreweryLogic.cs
@@ -17,7 +17,7 @@ namespace BreweryAPI.Logic
             _breweryRepository = breweryRepository;
         }
 
-        public async Task<IEnumerable<Brewery>> GetAllBreweriesAsync(string? search, string? city, string? sortBy, double? userLat, double? userLng, int page, int pageSize)
+        public async Task<PagedResult<Brewery>> GetAllBreweriesAsync(string? search, string? city, string? sortBy, double? userLat, double? userLng, int page, int pageSize)
         {
             IEnumerable<Brewery> data;
             if (!string.IsNullOrWhiteSpace(search))
@@ -30,9 +30,19 @@ namespace BreweryAPI.Logic
             if (!string.IsNullOrWhiteSpace(sortBy))
                 data = Sort(data, sortBy, userLat, userLng);
 
-            data = data.Skip((page - 1) * pageSize).Take(pageSize);
+            var totalCount = data.Count();
+            var totalPages = (int)Math.Ceiling((double)totalCount / pageSize);
 
-            return data;
+            var items = data.Skip((page - 1) * pageSize).Take(pageSize).ToList();
+
+            return new PagedResult<Brewery>
+            {
+                TotalCount = totalCount,
+                Page = page,
+                PageSize = pageSize,
+                TotalPages = totalPages,
+                Items = items
+            };
         }
 
         public Task<Brewery?> GetBreweryByIdAsync(string id)

--- a/BreweryAPI/Logic/Interfaces/IBreweryLogic.cs
+++ b/BreweryAPI/Logic/Interfaces/IBreweryLogic.cs
@@ -8,7 +8,8 @@ namespace BreweryAPI.Logic.Interfaces
 {
     public interface IBreweryLogic
     {
-        Task<IEnumerable<Brewery>> GetAllBreweriesAsync(string? search, string? city, string? sortBy, double? userLat, double? userLng, int page, int pageSize);
+        Task<PagedResult<Brewery>> GetAllBreweriesAsync(
+            string? search, string? city, string? sortBy, double? userLat, double? userLng, int page, int pageSize);
         Task<Brewery?> GetBreweryByIdAsync(string id);
         Task<IEnumerable<Brewery>> SearchAsync(string query);
         Task<IEnumerable<Brewery>> GetByCityAsync(string city);

--- a/BreweryAPI/Models/PagedResult.cs
+++ b/BreweryAPI/Models/PagedResult.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BreweryAPI.Models
+{
+    public class PagedResult<T>
+    {
+        public int TotalCount { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+        public IEnumerable<T> Items { get; set; } = Enumerable.Empty<T>();
+    }
+}


### PR DESCRIPTION
Introduce pagination for brewery retrieval by modifying the existing logic to return a `PagedResult` model, which includes total counts and page information. Adjustments ensure proper handling of page size limits and enhance the API's usability.